### PR TITLE
Implemented goto-tab with Meta+Fn like in Linux text console

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -245,7 +245,7 @@ sub refresh {
    my $len = $ofs;
    my @ends;
    for my $tab (@{ $self->{tabs} }) {
-      my $name = substr($tab->{name} ? $tab->{name} : $idx, -$max_len);
+      my $name = substr($tab->{name} ? $tab->{name} : $idx + 1, -$max_len);
       ++$idx;
       $len += length($name) + 3;        # '| ' and ' '
       if ($tab == $self->{cur}) {
@@ -267,7 +267,7 @@ sub refresh {
 
    for (; $idx < @{ $self->{tabs} }; ++$idx) {
       my $tab = $self->{tabs}[$idx];
-      my $name = substr($tab->{name} ? $tab->{name} : $idx, -$max_len);
+      my $name = substr($tab->{name} ? $tab->{name} : $idx + 1, -$max_len);
       my $act = $self->tab_activity_mark($tab, $now);
       my $txt = sprintf "%s%s%s", $act, $name, matching_activity_mark $act;
       my $len = length $txt;


### PR DESCRIPTION
Hello,
I have implemented a quick jump to the first 12 terminals using Alt+Fnn keys. This is a feature I am used to, it was missing, now it isn't.
To make it easier to associate a tab with its Fnn key, I changed the default labeling to be 1-based. I find it more useful that way, if a bit less 1337 :P  I did keep it in a separate commit, just in case.
Here's a pull request, if you think this could be useful in your fork as well.
Cheers,
Enrico
