### PR TITLE
New tabs open in the current tab's working directory, and do not run -e

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -342,10 +342,39 @@ sub new_tab {
 
    push @urxvt::TERM_EXT, urxvt::ext::tabbedex::tab::;
 
+
+   my @args;
+   if (!@{ $self->{tabs} })
+   {
+      # Start the first tab as it is
+      @args = @{ $self->{argv} };
+   } else {
+      # Get the working directory of the current tab and prepend a -cd to the command line
+      my $term = $self->{cur}{term};
+      my @str = $term->XGetWindowProperty($term->parent, $self->{tab_title});
+      if (@str && $str[2]) {
+         my $str = decode("utf8", $str[2]);
+         if ($str =~ /: (.+)$/)
+         {
+            use Cwd 'abs_path';
+            use File::Path::Expand;
+            push @args, "-cd";
+            push @args, abs_path(expand_filename($1));
+         }
+      }
+
+      # For the other tabs, remove the -e part if it exists
+      for my $arg (@{ $self->{argv} })
+      {
+         last if $arg == '-e';
+         push @args, $arg;
+      }
+   }
+
    my $term = new urxvt::term
       $self->env, $urxvt::RXVTNAME,
       -embed => $self->parent,
-      @{ $self->{argv} };
+      @args;
 }
 
 


### PR DESCRIPTION
Hello,
here is another feature I need: when I open a new tab, I need it to open on the current directory of the current tab. That is, I need it to stay in the directory I'm working in.
I also use the -e option quite heavily: I would start it with urxvt -cd workdir -e vim todolist, then open new tabs to get the work done. Tabbedex reruns -e when starting new tabs, so I would get endless tabs with vim complaining that the file is already open. I also remove -e and all following args when creating new tabs.

Cheers,
Enrico
