### PR TITLE
Remove unicode from man page contents

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -63,7 +63,7 @@ position.
 =item B<Shift-Up>
 
 Allows current tab to be renamed.  Tab bar is shown if it was hidden, current
-tab’s name (if nay) is cleared and cursor is displayed in its place.  Typing
+tab's name (if any) is cleared and cursor is displayed in its place.  Typing
 text renames the tab, backspace or Ctrl+H delete the last character, Escape or
 Ctrl+C aborts the rename operation and Enter accepts the new name.
 


### PR DESCRIPTION
Replace apostrophe causing pod2man unicode erorr with an ASCII single-quote and docs build successfully.

It's a trivial change, but I for one can't pass up man pages when they're available! :grin: 

Thanks for sharing your code!!