### PR TITLE
Ignoring tab activity on lines at the bottom

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -275,15 +275,17 @@ can set the number of lines to ignore using this resource:
     URxvt.tabbedex.ignore-active-bot-lines:   1
 
 This might be useful if the inactive tab is running L<screen(1)> and has a
-status line which includes a clock, which would cause the timeout strings to
+status line that includes a clock, which would cause the activity marks to
 show up on the inactive tab title after a minute or less.
 
 If set to L<1>, the botton-most line on the screen will be ignored, and the
-timeout strings will only appear on an inactive tab for changes to other
-lines.  You can set this to the number rows of at the bottom of your terminal that
+activity marks will only appear on an inactive tab for changes to other
+lines.  You can set this to the number rows at the bottom of your terminal that
 you wish to ignore.
 
-If unspecified, the default setting for this resource is L<0>.
+If unspecified, the default setting for this resource is L<0>, which elicits
+the normally expected behavior of displaying activity marks on the title of
+an inactive tab for changes anywhere on that tab.
 
 =item B<tabbed.tabbedex-rs-prefix>: I<string>
 

--- a/tabbedex
+++ b/tabbedex
@@ -287,6 +287,25 @@ If unspecified, the default setting for this resource is L<0>, which elicits
 the normally expected behavior of displaying activity marks on the title of
 an inactive tab for changes anywhere on that tab.
 
+Note that this setting applies to ALL inactive tabs. If you would like to
+apply it only to specific tabs, see the L<ignore-lines-tab-name-pattern>
+resource.
+
+=item B<ignore-lines-tab-name-pattern>: I<string>
+
+Specify a pattern (regular expression) that tab names need to match in order for the
+I<ignore-active-bot-lines> resource to apply to them.  The default value is:
+
+    URxvt.tabbedex.ignore-lines-tab-name-pattern:    .*
+
+Which matches ALL tab names, but if you set it something else, like for
+example:
+
+    URxvt.tabbedex.ignore-lines-tab-name-pattern:    ^_
+
+Then only tabs whose names begin with an underscore will have some of their
+active lines ignored by the I<ignore-active-bot-lines> resource.
+
 =item B<tabbed.tabbedex-rs-prefix>: I<string>
 
 A B<deprecated> alternative resource name prefix.  It's always specified with

--- a/tabbedex
+++ b/tabbedex
@@ -267,6 +267,24 @@ As a deprecated feature, if a single character is given and it's (, [, { or <,
 matching closing brace will be used for right activity mark.  This is feature
 will be removed in the future.
 
+=item B<ignore-active-bot-lines>: I<string>
+
+If you wish to ignore activity coming from the bottom of an inactive tab, you
+can set the number of lines to ignore using this resource:
+
+    URxvt.tabbedex.ignore-active-bot-lines:   1
+
+This might be useful if the inactive tab is running L<screen(1)> and has a
+status line which includes a clock, which would cause the timeout strings to
+show up on the inactive tab title after a minute or less.
+
+If set to L<1>, the botton-most line on the screen will be ignored, and the
+timeout strings will only appear on an inactive tab for changes to other
+lines.  You can set this to the number rows of at the bottom of your terminal that
+you wish to ignore.
+
+If unspecified, the default setting for this resource is L<0>.
+
 =item B<tabbed.tabbedex-rs-prefix>: I<string>
 
 A B<deprecated> alternative resource name prefix.  It's always specified with
@@ -1066,6 +1084,7 @@ sub init {
    $root->{register_keysyms} = !$rs->bool('no-tabbedex-keys', 0);
    $root->{reopen_on_close}  = $rs->bool('reopen-on-close', 0);
    $root->{tab_arguments}    = $rs->text('tab-arguments', '');
+   $root->{ignore_active_bot_lines} = $rs->text('ignore-active-bot-lines', 0);
 
    # TODO: Remove the warning in late 2020.
    if (defined $rs->text('new-tab-command')) {
@@ -1228,6 +1247,23 @@ sub tab_add_lines {
 	();
 }
 
+sub tab_line_update {
+    my ($root, $tab, $row) = @_;
+    # Only allow activity in rows above the ignored ones:
+    if ( $row < ( $tab->nrow - $root->{ignore_active_bot_lines} ) ) {
+        if ($tab != $root->{cur}) {
+            my $now = urxvt::NOW;
+            my @pre = $root->tab_activity_marks($tab, $now);
+            $tab->{last_activity} = $now;
+            my @post = $root->tab_activity_marks($tab, $now);
+            if ($pre[0] ne $post[0] || $pre[1] ne $post[1]) {
+                $root->refresh($now);
+            }
+        }
+    }
+    ();
+}
+
 
 sub tab_action {
 	my ($root, $tab, $cmd) = @_;
@@ -1310,8 +1346,14 @@ use POSIX qw/tcgetpgrp/;
 
 
 sub enable_hooks {
-	for my $hook (qw(start destroy property_notify add_lines
-	                 bell osc_seq_perl)) {
+    my @hook_list;
+    if ( $_[0]{root}->{ignore_active_bot_lines} > 0 ) {
+        @hook_list = qw(start destroy property_notify line_update bell osc_seq_perl);
+    }
+    else {
+        @hook_list = qw(start destroy property_notify add_lines bell osc_seq_perl);
+    }
+	for my $hook (@hook_list) {
 		my $name = "urxvt::ext::tabbedex::root::tab_$hook";
 		$_[0]->enable($hook => sub {
 			unshift @_, $_[0]{root};

--- a/tabbedex
+++ b/tabbedex
@@ -1087,6 +1087,7 @@ sub init {
    $root->{reopen_on_close}  = $rs->bool('reopen-on-close', 0);
    $root->{tab_arguments}    = $rs->text('tab-arguments', '');
    $root->{ignore_active_bot_lines} = $rs->text('ignore-active-bot-lines', 0) + 0;
+   $root->{ignore_lines_tab_name_pattern} = $rs->text('ignore-lines-tab-name-pattern', '.*');
 
    # TODO: Remove the warning in late 2020.
    if (defined $rs->text('new-tab-command')) {
@@ -1251,9 +1252,13 @@ sub tab_add_lines {
 
 sub tab_line_update {
     my ($root, $tab, $row) = @_;
-    # Only allow activity in rows above the ignored ones:
-    if ( $row < ( $tab->nrow - $root->{ignore_active_bot_lines} ) ) {
-        if ($tab != $root->{cur}) {
+    # Only allow activity in rows above the ignored ones,
+    # for tabs whose names match the specified pattern:
+    if ($tab != $root->{cur}) {
+        my $regex = $root->{ignore_lines_tab_name_pattern};
+        if ( ( $tab->{name} =~ m/$regex/ &&
+               $row < ( $tab->nrow - $root->{ignore_active_bot_lines} ) ) ||
+             ( $tab->{name} !~ m/$regex/ ) ) {
             my $now = urxvt::NOW;
             my @pre = $root->tab_activity_marks($tab, $now);
             $tab->{last_activity} = $now;

--- a/tabbedex
+++ b/tabbedex
@@ -267,7 +267,7 @@ As a deprecated feature, if a single character is given and it's (, [, { or <,
 matching closing brace will be used for right activity mark.  This is feature
 will be removed in the future.
 
-=item B<ignore-active-bot-lines>: I<string>
+=item B<ignore-active-bot-lines>: I<number>
 
 If you wish to ignore activity coming from the bottom of an inactive tab, you
 can set the number of lines to ignore using this resource:
@@ -280,8 +280,8 @@ show up on the inactive tab title after a minute or less.
 
 If set to L<1>, the botton-most line on the screen will be ignored, and the
 activity marks will only appear on an inactive tab for changes to other
-lines.  You can set this to the number rows at the bottom of your terminal that
-you wish to ignore.
+lines.  You can set this to the number of rows at the bottom of your terminal
+that you wish to ignore.
 
 If unspecified, the default setting for this resource is L<0>, which elicits
 the normally expected behavior of displaying activity marks on the title of
@@ -1086,7 +1086,7 @@ sub init {
    $root->{register_keysyms} = !$rs->bool('no-tabbedex-keys', 0);
    $root->{reopen_on_close}  = $rs->bool('reopen-on-close', 0);
    $root->{tab_arguments}    = $rs->text('tab-arguments', '');
-   $root->{ignore_active_bot_lines} = $rs->text('ignore-active-bot-lines', 0);
+   $root->{ignore_active_bot_lines} = $rs->text('ignore-active-bot-lines', 0) + 0;
 
    # TODO: Remove the warning in late 2020.
    if (defined $rs->text('new-tab-command')) {


### PR DESCRIPTION
Hi Michal,

I used **urxvt** with **tabbedex**  several years ago, and I've recently come back to them, and discovered how useful they are for connecting to many remote systems on separate tabs.

One minor issue I found was when I use GNU Screen on the remote system and have a status line displaying a clock.  If one of these remote connections is not the current tab, I will get activity marks very often (due to the minutes on the clock).

This change will cause the activity on one or more lines at the bottom of the screen to be ignored by using the resource:

    URxvt.tabbedex.ignore-active-bot-lines:    1

If you do not set this resource, everything works as before, but if you set it to 1 or more, the `tab_line_update()` function is used instead of `tab_add_lines()` to determine activity on a tab which sets the activity marks.  This `tab_line_update()` function is triggered by the `line_update` hook, which is used in place of the `add_lines` hook, but only when the resource is not set to zero.  The `line_update` hook is aware of the line number that triggered the update, which makes it possible to ignore changes from specific lines.

I have added documentation in a section to the `urxvt-tabbedex` manpage.  I've been using this new feature for a couple of days and it's working well for me.

Let me know what you think.

--
Miguel