### PR TITLE
Fix for dead key problem

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -1001,6 +1001,11 @@ _on key_release => sub {
 
 sub key_event {
 	my ($root, $type, $event) = @_;
+
+	# Do nothing if a dead key is being pressed and the mouse cursor
+	# is outside the active urxvt window:
+	return if $type eq 'key_press' && $event->{state}==0 && $event->{keycode}==0 && $event->{time}==0;
+
 	my $tab = $root->{cur};
 	$tab->$type($event->{state}, $event->{keycode}, $event->{time});
 


### PR DESCRIPTION
When the mouse cursor is outside the active urxvt window dead
keys stop working, at least when using ibus. This small fix stops
the tabbedex extension from doing anyting when dead keys are
pressed under these circumstances, which sidesteps the issue.
Fixes https://github.com/mina86/urxvt-tabbedex/issues/26.