### PR TITLE
Replace non-ASCII wide character for pod2man.

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -355,8 +355,8 @@ switching right from the last tab or left from the first one.
 =item B<tabbedex:next_tab:nowrap> and B<tabbedex:prev_tab:nowrap>
 
 Switches tabs like B<tabbedex:next_tab> and B<tabbedex:prev_tab> action but does
-not wrap around.  I.e. does nothing if trying to switch to the last tab’s next
-tab or first tab’s previous tab.
+not wrap around.  I.e. does nothing if trying to switch to the last tab's next
+tab or first tab's previous tab.
 
 =item B<tabbedex:move_tab_left> and B<tabbedex:move_tab_right>
 


### PR DESCRIPTION
Hello!

I was unable to run the install script because pod2man complained of non-ASCII characters in the **tabbedex** file. I was able to solve this locally by replacing the non-ASCII characters and then running `make install-local-symlink`. Sending up this simple PR to hopefully get it fixed for everyone :). Thanks for maintaining this great tool for all urxvt users!

I have pasted the pod2man error message below for reference:
```
$ sh .urxvt/tabbedex/install
~/.urxvt/tabbedex already exist, overwrite? [y/N] y

Updating the repository
Fetching origin
HEAD is now at 7273e74 Fix incorrect geometry when border or scroll bar is enabled

Running as regular user, installing symbolic links locally
if ! pod2man tabbedex >tabbedex.1; then rm -- tabbedex.1; exit 1; fi
Wide character in printf at /usr/share/perl/5.32/Pod/Simple.pm line 573.
tabbedex around line 358: Non-ASCII character seen before =encoding in 'tab’s'. Assuming UTF-8
POD document had syntax errors at /bin/pod2man line 69.
make: *** [Makefile:22: tabbedex.1] Error 1
```
